### PR TITLE
Load ontology from VOWL JSON file specified by `url`.

### DIFF
--- a/src/app/js/menu/ontologyMenu.js
+++ b/src/app/js/menu/ontologyMenu.js
@@ -100,14 +100,17 @@ module.exports = function (graph) {
 
 		// IRI parameter
 		var iriKey = "iri=";
+		var urlKey = "url=";
 		var fileKey = "file=";
 		if (hashParameter.substr(0, fileKey.length) === fileKey) {
 			var filename = decodeURIComponent(hashParameter.slice(fileKey.length));
 			loadOntologyFromFile(filename);
+		} else if (hashParameter.substr(0, urlKey.length) === urlKey) {
+			var url = decodeURIComponent(hashParameter.slice(urlKey.length));
+			loadOntologyFromUri(url, url);
 		} else if (hashParameter.substr(0, iriKey.length) === iriKey) {
 			var iri = decodeURIComponent(hashParameter.slice(iriKey.length));
 			loadOntologyFromUri("convert?iri=" + encodeURIComponent(iri), iri);
-
 			d3.select("#converter-option").classed("selected-ontology", true);
 		} else {
 			// id of an existing ontology as parameter


### PR DESCRIPTION
This pull request adds ability to load an ontology in VOWL (JSON) format from Web via `url` query parameter.
Ofcource, you can rename `url` to something different if you want.