### PR TITLE
Fix version display

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -229,8 +229,8 @@
                     Vincent Link, Steffen Lohmann, Eduard Marbach, Stefan Negru, Vitalis Wiens
                 </li>
                 <!-- build:process -->
-                <li><a href="http://vowl.visualdataweb.org/webvowl.html#releases" target="_blank">Version: <%= version
-                    %><br/>(release history)</a></li>
+                <li><a href="http://vowl.visualdataweb.org/webvowl.html#releases" target="_blank">
+                    Version: <%= version %><br/>(release history)</a></li>
                 <!-- /build -->
                 <li><a href="http://purl.org/vowl/" target="_blank">VOWL Specification &raquo;</a></li>
             </ul>


### PR DESCRIPTION
The version display in the "about" menu is broken because of the line break.

![image](https://user-images.githubusercontent.com/17952318/69411816-f850c400-0d0d-11ea-8505-1b808183955c.png)


This PR fixes the problem

![image](https://user-images.githubusercontent.com/17952318/69411870-1c140a00-0d0e-11ea-9d11-c9b92c142904.png)
