### PR TITLE
Build WebVOWL and OWL2VOWL from source in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,56 @@
 # WebVOWL #
 ###########
 
-# Use tomcat java 8 alpine as base image
-FROM tomcat:9-jre8-alpine
+# Stage 1: Build OWL2VOWL converter from source
+FROM docker.io/maven:3-openjdk-8-slim AS owl2vowl-builder
 
-# Build time arguments (WebVOWL version)
-ARG version=1.1.7
+WORKDIR /owl2vowl
 
-# Download WebVOWL to tomcat webapps directory as root app
-RUN rm -rf /usr/local/tomcat/webapps/* && \
-    wget -O /usr/local/tomcat/webapps/ROOT.war http://vowl.visualdataweb.org/downloads/webvowl_1.1.7.war
+# Clone and build OWL2VOWL WAR
+RUN apt-get update && \
+    apt-get install -y git && \
+    git clone https://github.com/VisualDataWeb/OWL2VOWL.git . && \
+    mvn clean package -P war-release -DskipTests
 
-# Run default server
+# Stage 2: Build WebVOWL from source
+FROM docker.io/node:12-alpine AS webvowl-builder
+
+WORKDIR /build
+
+# Copy package files
+COPY package.json ./
+COPY Gruntfile.js ./
+COPY webpack.config.js ./
+
+# Copy source code and configuration
+COPY src ./src
+COPY util ./util
+COPY .jshintrc ./.jshintrc
+COPY .jshintignore ./.jshintignore
+
+# Install dependencies and build
+RUN npm install && \
+    npm run release
+
+# Stage 3: Runtime - Deploy both to Tomcat
+FROM docker.io/tomcat:9-jdk8-openjdk-slim
+
+# Remove default webapps
+RUN rm -rf /usr/local/tomcat/webapps/*
+
+# First, deploy OWL2VOWL WAR as ROOT (this provides the servlets)
+RUN mkdir -p /usr/local/tomcat/webapps/ROOT
+COPY --from=owl2vowl-builder /owl2vowl/target/*.war /tmp/owl2vowl.war
+RUN cd /usr/local/tomcat/webapps/ROOT && \
+    jar -xf /tmp/owl2vowl.war && \
+    rm /tmp/owl2vowl.war
+
+# Then, copy WebVOWL static files into the same ROOT context
+# This merges the static frontend with the backend servlets
+COPY --from=webvowl-builder /build/deploy /usr/local/tomcat/webapps/ROOT/
+
+# Expose port 8080
+EXPOSE 8080
+
+# Run Tomcat
 CMD ["catalina.sh", "run"]


### PR DESCRIPTION
Replace external WAR download with multi-stage Docker build that:
- Builds OWL2VOWL converter from GitHub source using Maven
- Builds WebVOWL frontend from local source using Node.js
- Deploys both to single Tomcat instance with merged context

This fixes the issue where the downloaded WAR file was corrupted or unavailable, and enables ontology conversion functionality by including the OWL2VOWL backend service alongside the WebVOWL frontend.

The OWL2VOWL servlets (serverTimeStamp, convert) are now accessible at the same context path as WebVOWL, allowing the conversion service to work correctly.

Works both for docker and podman

Changes:
- Use multi-stage build with maven:3-openjdk-8-slim for OWL2VOWL
- Use node:12-alpine for WebVOWL build
- Use tomcat:9-jdk8-openjdk-slim runtime (JDK needed for jar command)
- Extract OWL2VOWL WAR and overlay WebVOWL static files in ROOT context